### PR TITLE
Update apk package list before installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM gliderlabs/alpine:3.3
-RUN apk update \
-  && apk --no-cache add alpine-sdk coreutils \
+RUN apk --no-cache add alpine-sdk coreutils \
   && adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder \
   && echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 COPY /abuilder /bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM gliderlabs/alpine:3.3
-RUN apk --no-cache add alpine-sdk coreutils \
-  && adduser -G abuild -g "Alpine Package Builder" -s /bin/sh -D builder \
+RUN apk update \
+  && apk --no-cache add alpine-sdk coreutils \
+  && adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder \
   && echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 COPY /abuilder /bin/
 USER builder

--- a/abuilder
+++ b/abuilder
@@ -4,6 +4,7 @@ set -e
 
 main() {
   mkdir -p /home/builder/packages /home/builder/.abuild
+  abuild-apk update
   [ "$RSA_PRIVATE_KEY" ] && {
     echo -e "$RSA_PRIVATE_KEY" > "/home/builder/$RSA_PRIVATE_KEY_NAME"
     export PACKAGER_PRIVKEY="/home/builder/$RSA_PRIVATE_KEY_NAME"


### PR DESCRIPTION
:information_desk_person: As remote repository information can change, updating remote index information helps to ensure that the package information stored in the Docker image is up to date. This change runs `apk update` before any other actions, which prevent errors like the following (using [sgerrand/alpine-pkg-R](https://github.com/sgerrand/alpine-pkg-R) as an example):

Before:

```
$ docker run -e RSA_PRIVATE_KEY=$alpine_pkg_private_key -e RSA_PRIVATE_KEY_NAME=sgerrand.rsa -v $(pwd):/home/builder/package -v $(pwd)/packages:/home/builder/packages andyshinn/alpine-abuild
>>> R: Checking sanity of /home/builder/package/APKBUILD...
>>> R: Analyzing dependencies...
ERROR: unsatisfiable constraints:
  autoconf (missing):
    required by: world[autoconf]
  automake (missing):
    required by: world[automake]
  gfortran (missing):
    required by: world[gfortran]
  pcre-dev (missing):
    required by: world[pcre-dev]
  perl (missing):
    required by: world[perl]
  readline-dev (missing):
    required by: world[readline-dev]
>>> ERROR: R: all failed
>>> R: Uninstalling dependencies...
```

After:

```
$ docker run -e RSA_PRIVATE_KEY=$alpine_pkg_private_key -e RSA_PRIVATE_KEY_NAME=sgerrand.rsa -v $(pwd):/home/builder/package -v $(pwd)/packages:/home/builder/packages sgerrand/alpine-abuild:apk-update
>>> R: Checking sanity of /home/builder/package/APKBUILD...
>>> R: Analyzing dependencies...
WARNING: Ignoring /home/builder/packages//builder/x86_64/APKINDEX.tar.gz: No such file or directory
(1/17) Installing libpcre16 (8.38-r0)
(2/17) Installing libpcre32 (8.38-r0)
(3/17) Installing libpcrecpp (8.38-r0)
(4/17) Installing pcre-dev (8.38-r0)
(5/17) Installing perl (5.22.1-r0)
(6/17) Installing ncurses-terminfo-base (6.0-r6)
(7/17) Installing ncurses-terminfo (6.0-r6)
(8/17) Installing ncurses-libs (6.0-r6)
(9/17) Installing readline (6.3.008-r4)
(10/17) Installing readline-dev (6.3.008-r4)
(11/17) Installing m4 (1.4.17-r1)
(12/17) Installing autoconf (2.69-r0)
(13/17) Installing automake (1.15-r0)
(14/17) Installing libquadmath (5.3.0-r0)
(15/17) Installing libgfortran (5.3.0-r0)
(16/17) Installing gfortran (5.3.0-r0)
(17/17) Installing .makedepends-R (0)
Executing busybox-1.24.1-r7.trigger
OK: 266 MiB in 82 packages
>>> R: Cleaning temporary build dirs...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 28.4M  100 28.4M    0     0  11.8M      0  0:00:02  0:00:02 --:--:-- 12.0M
>>> R: Checking sha512sums...
glibc-0001-disable-stack-end.patch: OK
R-3.2.3.tar.gz: OK
>>> R: Unpacking /var/cache/distfiles/R-3.2.3.tar.gz...
>>> R: Applying glibc-0001-disable-stack-end.patch

(etc)
```
