### PR TITLE
Set default value for RSA_PRIVATE_KEY_NAME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,4 @@ USER builder
 ENTRYPOINT ["abuilder", "-r"]
 WORKDIR /home/builder/package
 ENV PACKAGER_PRIVKEY /home/builder/abuild.rsa
+ENV RSA_PRIVATE_KEY_NAME ssh.rsa

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ There are a number of environment variables you can change at package build time
 * `RSA_PRIVATE_KEY`: This is the contents of your RSA private key. This is optional. You should use `PACKAGER_PRIVKEY` and mount your private key if not using `PACKAGER_PRIVKEY`.
 * `RSA_PRIVATE_KEY_NAME`: Defaults to `ssh.rsa`. This is the name we will set the private key file as when using `RSA_PRIVATE_KEY`. The file will be written out to `/home/builder/$RSA_PRIVATE_KEY_NAME`.
 * `PACKAGER_PRIVKEY`: Defaults to `/package/abuild.rsa`. This is generally used if you are bind mounting your private key instead of passing it in with `RSA_PRIVATE_KEY`.
-* `REPODEST`: defaults to `/packages`. If you want to override the destination of the build packages.
-* `PACKAGER`: defaults to `Glider Labs <team@gliderlabs.com>`. This is the name of the package used in package metadata.
+* `REPODEST`: Defaults to `/packages`. If you want to override the destination of the build packages.
+* `PACKAGER`: Defaults to `Glider Labs <team@gliderlabs.com>`. This is the name of the package used in package metadata.
 
 ## Keys
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can also run the builder anywhere. You just need to mount your package sourc
 There are a number of environment variables you can change at package build time:
 
 * `RSA_PRIVATE_KEY`: This is the contents of your RSA private key. This is optional. You should use `PACKAGER_PRIVKEY` and mount your private key if not using `PACKAGER_PRIVKEY`.
-* `RSA_PRIVATE_KEY_NAME`: This is the name we will set the private key file as when using `RSA_PRIVATE_KEY`. The file will be written out to `/home/builder/$RSA_PRIVATE_KEY_NAME`.
+* `RSA_PRIVATE_KEY_NAME`: Defaults to `ssh.rsa`. This is the name we will set the private key file as when using `RSA_PRIVATE_KEY`. The file will be written out to `/home/builder/$RSA_PRIVATE_KEY_NAME`.
 * `PACKAGER_PRIVKEY`: Defaults to `/package/abuild.rsa`. This is generally used if you are bind mounting your private key instead of passing it in with `RSA_PRIVATE_KEY`.
 * `REPODEST`: defaults to `/packages`. If you want to override the destination of the build packages.
 * `PACKAGER`: defaults to `Glider Labs <team@gliderlabs.com>`. This is the name of the package used in package metadata.


### PR DESCRIPTION
:information_desk_person: If $RSA_PRIVATE_KEY_NAME is not set, `abuilder` will fail to run the following command and exit with an error:

```
echo -e "$RSA_PRIVATE_KEY" > "/home/builder/$RSA_PRIVATE_KEY_NAME"
```

This change adds a default value for this environment variable which can be overridden at runtime.

Fixes #4 
