### PR TITLE
Bump Alpine to v3.6, install cmake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:3.5
-RUN apk --no-cache add alpine-sdk coreutils \
+FROM alpine:3.6
+RUN apk --no-cache add alpine-sdk coreutils cmake \
   && adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder \
   && echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
   && mkdir /packages \


### PR DESCRIPTION
Bump Alpine Linux version to v3.6. There doesn't seem to be any breaking changes between the two releases that would warrant further modification to this Dockerfile.

I also added `cmake` as it's a very common package for configuring sources before the build. We could also consider adding `autoconf` too but I've decided to keep this PR as small as possible.

I guess the README will need editing if you decide to push this newer image to Docker Hub.