### PR TITLE
Ensure directory ownership for abuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,4 @@ WORKDIR /home/builder/package
 ENV RSA_PRIVATE_KEY_NAME ssh.rsa
 ENV PACKAGER_PRIVKEY /home/builder/${RSA_PRIVATE_KEY_NAME}
 ENV REPODEST /packages
+VOLUME ["/home/builder/package"]

--- a/abuilder
+++ b/abuilder
@@ -9,6 +9,8 @@ main() {
     echo -e "$RSA_PRIVATE_KEY" > "/home/builder/.abuild/$RSA_PRIVATE_KEY_NAME"
     export PACKAGER_PRIVKEY="/home/builder/.abuild/$RSA_PRIVATE_KEY_NAME"
   }
+  sudo chown -R builder:abuild /home/builder/package
+  sudo chown -R builder:abuild $REPODEST
 
   exec abuild "$@"
 }

--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -12,3 +12,4 @@ WORKDIR /home/builder/package
 ENV RSA_PRIVATE_KEY_NAME ssh.rsa
 ENV PACKAGER_PRIVKEY /home/builder/${RSA_PRIVATE_KEY_NAME}
 ENV REPODEST /packages
+VOLUME ["/home/builder/package"]

--- a/edge/abuilder
+++ b/edge/abuilder
@@ -9,6 +9,8 @@ main() {
     echo -e "$RSA_PRIVATE_KEY" > "/home/builder/.abuild/$RSA_PRIVATE_KEY_NAME"
     export PACKAGER_PRIVKEY="/home/builder/.abuild/$RSA_PRIVATE_KEY_NAME"
   }
+  sudo chown -R builder:abuild /home/builder/package
+  sudo chown -R builder:abuild $REPODEST
 
   exec abuild "$@"
 }


### PR DESCRIPTION
💁  In some circumstances, the bind mounts to the package build and output directories can result in them being owned by root. This causes the `abuild` process to fail when it attempts to create the `pkg` and `src` directories in `/home/builder/package/`. By explicitly changing ownership of these directories, the build process will run as expected - regardless of the Docker environment.