### PR TITLE
Bump Alpine to v3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 RUN apk --no-cache add alpine-sdk coreutils cmake \
   && adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder \
   && echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ We tag each release with a simple `v#` version scheme. Here are the tags to choo
 * `andyshinn/alpine-abuild:v2`: based on Alpine 3.4
 * `andyshinn/alpine-abuild:v3`: based on Alpine 3.5
 * `andyshinn/alpine-abuild:v4`: based on Alpine 3.6
+* `andyshinn/alpine-abuild:v5`: based on Alpine 3.6
+* `andyshinn/alpine-abuild:v6`: based on Alpine 3.7
 * `andyshinn/alpine-abuild:edge`: based on Alpine edge (includes testing repository as well)
 
 The builder is typically run from your Alpine Linux package source directory (changing `~/.abuild/mykey.rsa` and `~/.abuild/mykey.rsa.pub` to your packager private and public key locations):


### PR DESCRIPTION
💁 This change bumps the base Alpine image to [version 3.7](https://www.alpinelinux.org/posts/Alpine-3.7.0-released.html).