### PR TITLE
Bump Alpine Linux to v3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 RUN apk --no-cache add alpine-sdk coreutils cmake \
   && adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder \
   && echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ We tag each release with a simple `v#` version scheme. Here are the tags to choo
 * `andyshinn/alpine-abuild:v4`: based on Alpine 3.6
 * `andyshinn/alpine-abuild:v5`: based on Alpine 3.6
 * `andyshinn/alpine-abuild:v6`: based on Alpine 3.7
+* `andyshinn/alpine-abuild:v7`: based on Alpine 3.8
 * `andyshinn/alpine-abuild:edge`: based on Alpine edge (includes testing repository as well)
 
 The builder is typically run from your Alpine Linux package source directory (changing `~/.abuild/mykey.rsa` and `~/.abuild/mykey.rsa.pub` to your packager private and public key locations):


### PR DESCRIPTION
💁 Another year, another Alpine Linux point release. This change bumps the base Alpine image to [version 3.8](https://www.alpinelinux.org/posts/Alpine-3.8.0-released.html).