### PR TITLE
add apk cache support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ RUN apk --no-cache add alpine-sdk coreutils cmake \
   && adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder \
   && echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
   && mkdir /packages \
-  && chown builder:abuild /packages
+  && chown builder:abuild /packages \
+  && mkdir -p /var/cache/apk \
+  && ln -s /var/cache/apk /etc/apk/cache
 COPY /abuilder /bin/
 USER builder
 ENTRYPOINT ["abuilder", "-r"]

--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ Put your key files in a same place and destroy this container:
 ```
 docker rm -f keys
 ```
+
+## APK Cache
+
+The builder has configured APK to use `/var/cache/apk` as its cache directory. This directory can be mounted as a volume to prevent the repeated download of dependencies when building packages.

--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -4,7 +4,9 @@ RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositor
   && adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder \
   && echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
   && mkdir /packages \
-  && chown builder:abuild /packages
+  && chown builder:abuild /packages \
+  && mkdir -p /var/cache/apk \
+  && ln -s /var/cache/apk /etc/apk/cache
 COPY /abuilder /bin/
 USER builder
 ENTRYPOINT ["abuilder", "-r"]


### PR DESCRIPTION
Simple mod to allow mounting of cache directory by configuring apk to use a local cache directory.

For reference: https://wiki.alpinelinux.org/wiki/Local_APK_cache